### PR TITLE
Allow XML::Reader to be used without specifying a backend - defaults to XML::Reader

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,12 @@
 Revision history for XML-Reader
 
+0.66 - 2018-01-30T10:00:00+01:00
+
+  [DOCUMENTATION]
+
+  - 'use' this module now defaults to using XML::Parser, and only if
+    this fails, fallback to XML::Parsepp.
+
 0.65 - 2014-12-28T09:24:30+01:00
 
   [DOCUMENTATION]

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name = XML-Reader
-version = 0.65
+version = 0.66
 author = Klaus Eichner <klaus03@gmail.com>
 license = Perl_5
 copyright_holder = Klaus Eichner
@@ -33,3 +33,7 @@ die_on_line_insertion=1
 [PodSyntaxTests]
 
 [AutoPrereqs]
+
+[Prereqs / TestRequires]
+XML::Parser  = 0
+XML::Parsepp = 0

--- a/dist.ini
+++ b/dist.ini
@@ -34,6 +34,6 @@ die_on_line_insertion=1
 
 [AutoPrereqs]
 
-[Prereqs / TestRequires]
+[Prereqs / DevelopRequires]
 XML::Parser  = 0
 XML::Parsepp = 0

--- a/lib/XML/Reader.pm
+++ b/lib/XML/Reader.pm
@@ -37,9 +37,7 @@ sub import {
         }
     }
 
-    if (defined $act_module) {
-        activate($act_module);
-    }
+    activate($act_module);
 
     XML::Reader->export_to_level(1, $calling_module, @plist);
 }
@@ -47,14 +45,27 @@ sub import {
 sub activate {
     my ($mod) = @_;
 
-    if ($mod eq 'XML::Parser') {
-        require XML::Parser;
+    if (defined $mod) {
+        if ($mod eq 'XML::Parser') {
+            require XML::Parser;
+        }
+        elsif ($mod eq 'XML::Parsepp') {
+            require XML::Parsepp;
+        }
+        else {
+            die "Can't identify module = '$mod'";
+        }
     }
-    elsif ($mod eq 'XML::Parsepp') {
-        require XML::Parsepp;
-    }
-    else {
-        die "Can't identify module = '$mod'";
+    else { # No backend provided - try to do the right thing
+        $mod = 'XML::Parser';
+        eval { require XML::Parser; };
+        if ($@) {
+            $mod = 'XML::Parsepp';
+            eval { require XML::Parsepp; };
+            if ($@) {
+                die "Error: Either XML::Parser or XML::Parsepp must be installed to run XML::Reader";
+            }
+        }
     }
 
     $use_module = $mod;

--- a/lib/XML/Reader.pm
+++ b/lib/XML/Reader.pm
@@ -1074,9 +1074,12 @@ you use XML::Reader::PP (which uses XML::Parsepp).
 
 However, if you use XML::Reader directly, here is how you switch between XML::Parser and XML::Parsepp:
 
-XML::Reader uses XML::Parser as the underlying Parser module. That works very well, except for cases where
-people don't have a C-compiler available to install XML::Parser. In those cases, XML::Parsepp can be used
-as a pure Perl alternative to XML::Parser. Here is an example:
+If no parser is given in the C<use> statement, XML::Reader tries to load XML::Parser.  That works very well, except
+for cases where people don't have a C-compiler available to install XML::Parser.  If loading XML::Parser fails, the
+module falls back to loading XML::Parsepp.
+
+It is also possible to explicitly select the parser. In the example below, XML::Parser is chosen explicitly, so
+compilation will fail if that module isn't available.
 
   use XML::Reader qw(XML::Parser);
 

--- a/lib/XML/Reader_de.pod
+++ b/lib/XML/Reader_de.pod
@@ -49,9 +49,14 @@ benutzt) oder man benutzt XML::Reader::PP (welches XML::Parsepp benutzt).
 Falls man dennoch XML::Reader direkt benutzen will, hier ist die Beschreibung wie man zwischen XML::Parser und XML::Parsepp
 auswE<auml>hlt:
 
-XML::Reader benutzt XML::Parser als Parser Modul. Das funktioniert sehr gut, ausser in den FE<auml>llen in denen kein
-C-compiler zur verfE<uuml>gung steht um XML::Parser zu installieren. In diesen FE<auml>llen kann XML::Parsepp 
-als eine Perl Alternative zu XML::Parser benutzt werden. Hier ist ein Beispiel:
+Wenn bei der C<use>-Anweisung keine Angabe zum Parser Modul gemacht wird, lE<auml>dt XML::Reader zunE<auml>chst
+XML::Parser.  Das funktioniert sehr gut, ausser in den FE<auml>llen in denen kein C-compiler zur verfE<uuml>gung
+steht um XML::Parser zu installieren.  Wenn also das Laden von XML::Parser fehlschlE<auml>gt, wird XML::Parsepp als
+Ersatz geladen.
+
+Es ist auch mE<ouml>glich, den Parser explizit auszuwE<auml>hlen.  Im folgenden Beispiel wird XML::Parser
+ausgewE<auml>hlt, so dass nun die E<Uuml>bersetzung des Moduls fehlschlE<auml>gt, wenn XML::Parser nicht
+verfE<uuml>gbar ist.
 
   use XML::Reader qw(XML::Parser);
 

--- a/xt/author/0010_autoload_parser.t
+++ b/xt/author/0010_autoload_parser.t
@@ -1,0 +1,14 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+# This test verifies that XML::Reader uses XML::Parser
+# if the user doesn't provide a backend module
+
+use XML::Reader; # no specification of a backend
+
+ok($INC{'XML/Parser.pm'},'XML::Parser is used as a backend');
+ok(! exists $INC{'XML/Parsepp.pm'}, 'XML::Parsepp is not used');
+
+done_testing;

--- a/xt/author/0010_autoload_parser.t
+++ b/xt/author/0010_autoload_parser.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More;
+use Test::More tests => 2;
 
 # This test verifies that XML::Reader uses XML::Parser
 # if the user doesn't provide a backend module
@@ -10,5 +10,3 @@ use XML::Reader; # no specification of a backend
 
 ok($INC{'XML/Parser.pm'},'XML::Parser is used as a backend');
 ok(! exists $INC{'XML/Parsepp.pm'}, 'XML::Parsepp is not used');
-
-done_testing;

--- a/xt/author/0020_fallbackload_parsepp.t
+++ b/xt/author/0020_fallbackload_parsepp.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+
+use Test::More;
+use File::Temp ('tempdir');
+
+# This test verifies that XML::Reader uses XML::Parsepp as fallback if
+# the user doesn't provide a backend module and XML::Parser is not
+# available.
+
+my $lib;
+BEGIN {
+    $lib = tempdir ( CLEANUP => 1 );
+    mkdir "$lib/XML";
+    open (my $fh, '>', "$lib/XML/Parser.pm");
+    print $fh '0;';
+    close $fh;
+    -e "$lib/XML/Parser.pm"
+        or die "Failed to create fake XML::Parser";
+}
+use lib $lib;
+
+use XML::Reader; # no specification of a backend
+
+ok($INC{'XML/Parsepp.pm'},'XML::Parsepp is used as a backend');
+ok(! exists $INC{'XML/Parser.pm'}, 'XML::Parser is not used');
+
+done_testing;

--- a/xt/author/0020_fallbackload_parsepp.t
+++ b/xt/author/0020_fallbackload_parsepp.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More;
+use Test::More tests => 2;
 use File::Temp ('tempdir');
 
 # This test verifies that XML::Reader uses XML::Parsepp as fallback if
@@ -24,5 +24,3 @@ use XML::Reader; # no specification of a backend
 
 ok($INC{'XML/Parsepp.pm'},'XML::Parsepp is used as a backend');
 ok(! exists $INC{'XML/Parser.pm'}, 'XML::Parser is not used');
-
-done_testing;

--- a/xt/author/0030_no_backend.t
+++ b/xt/author/0030_no_backend.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More;
+use Test::More tests => 1;
 use File::Temp ('tempdir');
 
 # This test verifies that XML::Reader throws an error at compile time
@@ -24,5 +24,3 @@ use lib $lib;
 
 eval "use XML::Reader;";
 like($@,qr/^Error:/,'No backend gives failure at compile time');
-
-done_testing;

--- a/xt/author/0030_no_backend.t
+++ b/xt/author/0030_no_backend.t
@@ -1,0 +1,28 @@
+use strict;
+use warnings;
+
+use Test::More;
+use File::Temp ('tempdir');
+
+# This test verifies that XML::Reader throws an error at compile time
+# if the user doesn't provide a backend module and neither XML::Parser
+# nor XML::Parsepp are available.
+
+my $lib;
+BEGIN {
+    $lib = tempdir ( CLEANUP => 1 );
+    mkdir "$lib/XML";
+    for my $module (qw(Parser Parsepp)) {
+        open (my $fh, '>', "$lib/XML/$module.pm");
+        print $fh '0;';
+        close $fh;
+        -e "$lib/XML/$module.pm"
+            or die "Failed to create fake XML::$module";
+    }
+}
+use lib $lib;
+
+eval "use XML::Reader;";
+like($@,qr/^Error:/,'No backend gives failure at compile time');
+
+done_testing;


### PR DESCRIPTION
This pull request is motivated by this year's CPAN Pull Request Challenge.

The change allows to 'use XML::Reader;' without specifying a backend.  In that case, XML::Reader will now try to load XML::Parser, and if this fails, fall back to XML::Parsepp.  This is similar to the behaviour of the modules Text::CSV or JSON which also have a XS and a pure perl implementation.

Tests simulating the absence of modules are included in the xt/author section, so that they will not be executed during an install.

Documentation is amended in English and German - but I fail to speak French, so I have to apologize that the French version is missing.