### PR TITLE
Add META.json to the distribution

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,11 @@
 Revision history for XML-Reader
 
+0.66 - 2018-01-30T09:30:00+01:00
+
+  [DOCUMENTATION]
+
+  - Add META.json to the package
+
 0.65 - 2014-12-28T09:24:30+01:00
 
   [DOCUMENTATION]

--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name = XML-Reader
-version = 0.65
+version = 0.66
 author = Klaus Eichner <klaus03@gmail.com>
 license = Perl_5
 copyright_holder = Klaus Eichner
@@ -14,6 +14,7 @@ allow_dirty=
 [PruneCruft]
 [ManifestSkip]
 [MetaYAML]
+[MetaJSON]
 [License]
 [Readme]
 [ExtraTests]


### PR DESCRIPTION
This is a rather trivial pull request, also motivated by this year's CPAN Pull Request Challenge.
It adds a META.json file to the distribution by simply adding one line to dist.ini.
The JSON format contains some more meta data than the YML format (which is already included), e.g. it lists Test::Pod as a requirement for the developer.